### PR TITLE
Upgrade sprockets version

### DIFF
--- a/lib/sprockets2/es6/version.rb
+++ b/lib/sprockets2/es6/version.rb
@@ -1,5 +1,5 @@
 module Sprockets2
   module ES6
-    VERSION = "0.0.1"
+    VERSION = "0.0.2"
   end
 end

--- a/sprockets2-es6.gemspec
+++ b/sprockets2-es6.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'babel-transpiler'
   spec.add_dependency 'babel-source', '>= 5.8.11'
-  spec.add_dependency 'sprockets', '~> 2.0'
+  spec.add_dependency 'sprockets', '>= 2.12.5'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
https://github.com/Mixbook/mixbook_com/network/alert/Gemfile.lock/sprockets/open

https://nvd.nist.gov/vuln/detail/CVE-2018-3760

This does not work with rails 3.2.22 and will require a upgrade to a newer version of rails.  

We have the following line in our production.rb, because we precompile our assets.  Turning off asset compilation on the production site should provide a workaround for this vulnerability.
config.assets.compile = false

Partially Implements: https://github.com/Mixbook/product/issues/7550
